### PR TITLE
Remove colab text

### DIFF
--- a/hvplot_interactive.ipynb
+++ b/hvplot_interactive.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Import and configure packages\n",
     "\n",
-    "Please note that in **Colab** you will need to `!pip install panel hvplot` and add `comms='colab'` to `pn.extension`."
+    "Please note that in **Colab** you will need to `!pip install panel hvplot`."
    ]
   },
   {
@@ -48,8 +48,7 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "pn.extension('tabulator', sizing_mode=\"stretch_width\")\n",
-    "# pn.extension('tabulator', sizing_mode=\"stretch_width\", comms=\"colab\")"
+    "pn.extension('tabulator', sizing_mode=\"stretch_width\")"
    ]
   },
   {


### PR DESCRIPTION
Hi @sophiamyang 

I found out that `comms='colab'` is no longer needed. See https://github.com/holoviz/panel/issues/2242#issuecomment-1014479544

I've tested that it works.

